### PR TITLE
refactor: add write permissions for workflows in schedule update

### DIFF
--- a/.github/workflows/schedule_update-from-template.yaml
+++ b/.github/workflows/schedule_update-from-template.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      workflows: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0


### PR DESCRIPTION
Enhanced the permissions in the schedule update workflow to include write access for workflows.

## Summary
What changed and why?

## Notes
- [ ] Code works
- [ ] Docs/configs updated (if needed)
- [ ] Tests (if any)
